### PR TITLE
Update CameraSession+Configuration.kt

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
@@ -342,6 +342,7 @@ internal fun CameraSession.configureIsActive(config: CameraConfiguration) {
   if (config.isActive) {
     lifecycleRegistry.currentState = Lifecycle.State.STARTED
     lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+    configureSideProps(config)
   } else {
     lifecycleRegistry.currentState = Lifecycle.State.STARTED
     lifecycleRegistry.currentState = Lifecycle.State.CREATED


### PR DESCRIPTION
Issue: 3027
When camera is set to be active the side props needs to be reapplied as it is a known bug where zoom level gets resets on CameraX module after camera is set to inactive.

https://github.com/mrousavy/react-native-vision-camera/issues/3027

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Android: Camera sideProps reflection on initialization and active state change

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

This PR adds a patch to re configure the side props whenver camera active state changes
<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

- Redmi 12, Android 14
- Redmi Pad Pro, Android 14
- Samsung M53, Android 13
<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

Fixes [#3027](https://github.com/mrousavy/react-native-vision-camera/issues/3027)
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
